### PR TITLE
Update OpenBLAS to 0.3.33

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
   build-darwin-m1:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Spack installations
         run: |
@@ -20,7 +20,7 @@ jobs:
           spack install
       
       - name: Upload Spack build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pluscilib-darwin-m1
           path: spack-environments/darwin-m1/.spack-env/view/
@@ -29,7 +29,7 @@ jobs:
   build-linux-aarch64:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Spack installations
         run: |
@@ -40,7 +40,7 @@ jobs:
           spack install
       
       - name: Upload Spack build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pluscilib-linux-aarch64
           path: spack-environments/linux-aarch64/.spack-env/view/
@@ -49,7 +49,7 @@ jobs:
   build-linux-neoverse_v2:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Spack installations
         run: |
@@ -61,7 +61,7 @@ jobs:
           spack install
       
       - name: Upload Spack build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pluscilib-linux-neoverse_v2
           path: spack-environments/linux-neoverse_v2/.spack-env/view/
@@ -70,7 +70,7 @@ jobs:
   build-linux-x86_64:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Spack installations
         run: |
@@ -82,7 +82,7 @@ jobs:
           spack install
       
       - name: Upload Spack build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pluscilib-linux-x86_64
           path: spack-environments/linux-x86_64/.spack-env/view/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           echo "build-run-id=$BUILD_RUN_ID" >> $GITHUB_OUTPUT
           echo "checkout-ref=$CHECKOUT_REF" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.release-source.outputs.checkout-ref }}
       
@@ -86,7 +86,7 @@ jobs:
           echo "latest-tag=$LATEST_TAG" >> $GITHUB_OUTPUT
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ steps.release-source.outputs.build-run-id }}

--- a/spack-environments/darwin-m1/spack.yaml
+++ b/spack-environments/darwin-m1/spack.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - openblas@0.3.27 shared=false build_system=cmake
+  - openblas@0.3.33 shared=false build_system=cmake
 
   toolchains:
     clang_fortran:

--- a/spack-environments/linux-aarch64/spack.yaml
+++ b/spack-environments/linux-aarch64/spack.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - openblas@0.3.27 shared=false
+  - openblas@0.3.33 shared=false
 
   packages:
     all:

--- a/spack-environments/linux-neoverse_v2/spack.yaml
+++ b/spack-environments/linux-neoverse_v2/spack.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - openblas@0.3.29 shared=false
+  - openblas@0.3.33 shared=false
 
   packages:
     all:
@@ -9,5 +9,7 @@ spack:
   concretizer:
     unify: when_possible
     reuse: false
+    targets:
+      host_compatible: false
 
   view: true

--- a/spack-environments/linux-x86_64/spack.yaml
+++ b/spack-environments/linux-x86_64/spack.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-  - openblas@0.3.29 shared=false
+  - openblas@0.3.33 shared=false
 
   packages:
     all:


### PR DESCRIPTION
## Summary
- Update all Spack environments to OpenBLAS 0.3.33
- Allow the Neoverse V2 environment to concretize a non-host-compatible target so CI produces target=neoverse_v2 instead of falling back to the ARM runner host target

## Validation
- Build workflow run succeeded on branch update-openblas-0.3.33: https://github.com/bmurakami/plumeria-scientific-libraries/actions/runs/26003373465
- Verified linux-neoverse_v2 concretizes OpenBLAS as target=neoverse_v2